### PR TITLE
Fixing third argument error when instance the installer on Plugin class

### DIFF
--- a/src/Vocento/Composer/Installers/Installer.php
+++ b/src/Vocento/Composer/Installers/Installer.php
@@ -43,7 +43,7 @@ class Installer extends LibraryInstaller
      * @param Filesystem $filesystem
      * @param BinaryInstaller $binaryInstaller
      */
-    public function __construct(IOInterface $io, Composer $composer, $type, Filesystem $filesystem, BinaryInstaller $binaryInstaller)
+    public function __construct(IOInterface $io, Composer $composer, $type = 'library', Filesystem $filesystem = null, BinaryInstaller $binaryInstaller = null)
     {
         parent::__construct($io, $composer, $type);
 


### PR DESCRIPTION
Fixing third argument error when instance the installer on Plugin class by adding a default value for $type argument
