### PR TITLE
Fix to add Windows compatibility and README updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,16 @@ to load the custom installers.
 
 This would install your package to the root path when a user runs `php composer.phar install`.
 
-**Extra Configurations**:
+## Extra Configurations
 
-This package have the possibility of setup some extra configs related to ignoring files on the install proccesses of
-the packages. There is a general config to exclude files from all packages that will be installed and there are
-three configs to exclude files for each package that can be installed. The names for the general exclude files
-configuration and for the three supported packages types configurations are:
+This package has the possibility of setup some extra configurations related to ignoring files on the install proccesses of the packages. There is a general configuration to exclude files from all packages that will be installed, and there are three configurations to exclude files for each package that can be installed. 
 
-    -'exclude-magento-files'
-    -'exclude-magento-core-files'
-    -'exclude-magento-community-files'
-    -'exclude-magento-statics-files'
+The names for the general exclude files configuration and for the three supported packages types configurations are:
+
+- `exclude-magento-files`
+- `exclude-magento-core-files`
+- `exclude-magento-community-files`
+- `exclude-magento-statics-files`
 
 You can add custom exclude-file configurations to your own custom installers.
 
@@ -62,12 +61,15 @@ composer.json file. Example:
     "type": "vocento-magento-core",
     "require": {
         "vocento/magento-composer-installers": "~1.0"
-    }
+    },
     "config": {
         "exclude-magento-files": [
-          "file1",
-          "file2",
-          ...
+          "excluded all packages file1",
+          "excluded all packages file2"
+        ],
+        "exclude-magento-core-files": [
+          "excluded magento core file1",
+          "excluded magento core file2"
         ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ custom installer to handle it.
 | Framework    | Types
 | ---------    | -----
 | Magento      | `vocento-magento-core`
+| Magento      | `vocento-magento-community`
+| Magento      | `vocento-magento-statics`
 
 ## Example `composer.json` File
 
@@ -37,3 +39,36 @@ to load the custom installers.
 
 This would install your package to the root path when a user runs `php composer.phar install`.
 
+**Extra Configurations**:
+
+This package have the possibility of setup some extra configs related to ignoring files on the install proccesses of
+the packages. There is a general config to exclude files from all packages that will be installed and there are
+three configs to exclude files for each package that can be installed. The names for the general exclude files
+configuration and for the three supported packages types configurations are:
+
+    -'exclude-magento-files'
+    -'exclude-magento-core-files'
+    -'exclude-magento-community-files'
+    -'exclude-magento-statics-files'
+
+You can add custom exclude-file configurations to your own custom installers.
+
+You can use these extra configurations adding a config node with these names and the files to be excluded on the
+composer.json file. Example:
+
+```json
+{
+    "name": "vocento/magento-core",
+    "type": "vocento-magento-core",
+    "require": {
+        "vocento/magento-composer-installers": "~1.0"
+    }
+    "config": {
+        "exclude-magento-files": [
+          "file1",
+          "file2",
+          ...
+        ]
+    }
+}
+```

--- a/src/Vocento/Composer/Installers/GitIgnore.php
+++ b/src/Vocento/Composer/Installers/GitIgnore.php
@@ -49,6 +49,7 @@ class GitIgnore
     public function addEntry($file)
     {
         $file = $this->prependSlashIfNotExist($file);
+        $file = $this->addWindowsCompatibility($file);
         if (!in_array($file, $this->lines)) {
             $this->lines[] = $file;
             $this->hasChanges = true;
@@ -127,6 +128,17 @@ class GitIgnore
     private function prependSlashIfNotExist($file)
     {
         return sprintf('/%s', ltrim($file, '/'));
+    }
+
+    /**
+     * Replaces backslash with slash for windows compatibility
+     *
+     * @param string $file
+     * @return string
+     */
+    private function addWindowsCompatibility($file)
+    {
+        return strtr($file, array('\\' => '/'));
     }
 
     /**


### PR DESCRIPTION
Fix to add Windows compatibility due to problem with backslashes when using DIRECTORY_SEPARATOR constant and README updated with last features and changes.
