### PR TITLE
Add more files to global ignore

### DIFF
--- a/src/Vocento/Composer/Installers/MagentoInstaller.php
+++ b/src/Vocento/Composer/Installers/MagentoInstaller.php
@@ -67,8 +67,11 @@ abstract class MagentoInstaller implements MagentoInstallerInterface
         $this->baseDir = $baseDir;
 
         $this->excludedFiles = [
-            'composer.json',
+            '.env',
             '.gitignore',
+            'composer.json',
+            'composer.lock',
+            'phpunit.xml.dist',
         ];
 
         $configExcludedFiles = $this->composer->getConfig()->get('exclude-magento-files');


### PR DESCRIPTION
Now some new files will be ignored by default:
- `.env`
- `.gitignore`
- `composer.json`
- `composer.lock`
- `phpunit.xml.dist`
