### PR TITLE
Adding build_package.sh file to the ones excluded when copying from vendor to root folder

### DIFF
--- a/src/Vocento/Composer/Installers/MagentoInstaller.php
+++ b/src/Vocento/Composer/Installers/MagentoInstaller.php
@@ -91,6 +91,7 @@ abstract class MagentoInstaller implements MagentoInstallerInterface
             'LICENSE_AFL.txt',
             'RELEASE_NOTES.txt',
             'package.xml',
+            'build_package.sh',
         ];
 
         $configExcludedFiles = $this->composer->getConfig()->get('exclude-magento-files');


### PR DESCRIPTION
Adding build_package.sh file to the ones excluded when copying from vendor to root folder